### PR TITLE
Set commander's arg more properly

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,28 +13,37 @@ export async function main() {
   const program = new Command();
 
   program
-    .command("init <type> <folderName>")
+    .command("init")
     .description("Initialize a new project")
+    .argument("type", "The type of project to initialize, 'c' or 'js'")
+    .argument("folderName", "The name of the folder to initialize")
     .action(initCommand);
 
   program
-    .command("compile-js <inPath> [outDir]")
+    .command("compile-js")
     .description("Compile JS/TS files")
+    .argument("inPath", "The path to the input file")
+    .argument("outDir", "The path to the output directory")
     .action(compileJSCommand);
 
   program
-    .command("compile-c <inPath> [outDir]")
+    .command("compile-c")
     .description("Compile C files")
+    .argument("inPath", "The path to the input file or directory")
+    .argument("outDir", "The path to the output directory")
     .action(compileCCommand);
 
   program
-    .command("debug <accountLabel> <accountValue>")
+    .command("debug")
     .description("Debug with a selected account")
+    .argument("label", "The label of the account to debug")
+    .argument("r-address", "The r-address of the account to debug")
     .action(debugCommand);
 
   program
-    .command("newcreds <name>")
+    .command("newcreds")
     .description("Create new credentials for an account")
+    .argument("name", "The name of the account to create credentials for")
     .action(newCredsCommand);
 
   await program.parseAsync(process.argv);


### PR DESCRIPTION
This makes users to display help for each subcommand.

`hooks-cli init -h`

```txt
Usage: cli init [options] <type> <folderName>

Initialize a new project

Arguments:
  type        The type of project to initialize, 'c' or 'js'
  folderName  The name of the folder to initialize

Options:
  -h, --help  display help for command
```