### PR TITLE
Fix saving binary file as hex in js2wasm

### DIFF
--- a/src/js2wasm/index.ts
+++ b/src/js2wasm/index.ts
@@ -159,7 +159,7 @@ async function saveFileOrError(
     );
     fs.writeFileSync(
       path.join(outDir + "/" + filename + ".bc"),
-      Buffer.from(Buffer.from(binary).toString(), "hex")
+      Buffer.from(binary)
     );
   }
 }


### PR DESCRIPTION
# Breaking Change

- Current implementation of C Hooks
https://github.com/Xahau/hooks-cli/blob/bd6cf407935d0d6e181ca6349391236e1f2bc4af/src/c2wasm/index.ts#L124

https://github.com/Xahau/xrpl-hooks-compiler/pull/36