### PR TITLE
Add alias for js2wasm-cli, c2wasm-cli

### DIFF
--- a/bin/c2wasm-cli.js
+++ b/bin/c2wasm-cli.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { main } = require("../dist/npm/src/cli");
+
+async function run() {
+  await main("c");
+}
+
+run();

--- a/bin/js2wasm-cli.js
+++ b/bin/js2wasm-cli.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { main } = require("../dist/npm/src/cli");
+
+async function run() {
+  await main("js");
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "src"
   ],
   "bin": {
-    "hooks-cli": "./bin/cli.js"
+    "hooks-cli": "./bin/cli.js",
+    "js2wasm-cli": "./bin/js2wasm-cli.js",
+    "c2wasm-cli": "./bin/c2wasm-cli.js"
   },
   "scripts": {
     "build": "tsc && cp -r src/init dist/npm/src",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,42 +9,64 @@ import {
   newCredsCommand,
 } from "./commands";
 
-export async function main() {
+type Target = "c" | "js";
+
+export async function main(target?: Target) {
   const program = new Command();
 
-  program
-    .command("init")
-    .description("Initialize a new project")
-    .argument("type", "The type of project to initialize, 'c' or 'js'")
-    .argument("folderName", "The name of the folder to initialize")
-    .action(initCommand);
+  if (target === "c") {
+    program
+      .description("Compile C files")
+      .argument("inPath", "The path to the input file or directory")
+      .argument("outDir", "The path to the output directory")
+      .showHelpAfterError()
+      .action(compileCCommand);
+  } else if (target === "js") {
+    program
+      .description("Compile JS/TS files")
+      .argument("inPath", "The path to the input file")
+      .argument("outDir", "The path to the output directory")
+      .showHelpAfterError()
+      .action(compileJSCommand);
+  } else {
+    program
+      .command("init")
+      .description("Initialize a new project")
+      .argument("type", "The type of project to initialize, 'c' or 'js'")
+      .argument("folderName", "The name of the folder to initialize")
+      .showHelpAfterError()
+      .action(initCommand);
 
-  program
-    .command("compile-js")
-    .description("Compile JS/TS files")
-    .argument("inPath", "The path to the input file")
-    .argument("outDir", "The path to the output directory")
-    .action(compileJSCommand);
+    program
+      .command("compile-js")
+      .description("Compile JS/TS files")
+      .argument("inPath", "The path to the input file")
+      .argument("outDir", "The path to the output directory")
+      .showHelpAfterError()
+      .action(compileJSCommand);
 
-  program
-    .command("compile-c")
-    .description("Compile C files")
-    .argument("inPath", "The path to the input file or directory")
-    .argument("outDir", "The path to the output directory")
-    .action(compileCCommand);
+    program
+      .command("compile-c")
+      .description("Compile C files")
+      .argument("inPath", "The path to the input file or directory")
+      .argument("outDir", "The path to the output directory")
+      .showHelpAfterError()
+      .action(compileCCommand);
 
-  program
-    .command("debug")
-    .description("Debug with a selected account")
-    .argument("label", "The label of the account to debug")
-    .argument("r-address", "The r-address of the account to debug")
-    .action(debugCommand);
+    program
+      .command("debug")
+      .description("Debug with a selected account")
+      .argument("label", "The label of the account to debug")
+      .argument("r-address", "The r-address of the account to debug")
+      .showHelpAfterError()
+      .action(debugCommand);
 
-  program
-    .command("newcreds")
-    .description("Create new credentials for an account")
-    .argument("name", "The name of the account to create credentials for")
-    .action(newCredsCommand);
-
+    program
+      .command("newcreds")
+      .description("Create new credentials for an account")
+      .argument("name", "The name of the account to create credentials for")
+      .showHelpAfterError()
+      .action(newCredsCommand);
+  }
   await program.parseAsync(process.argv);
 }


### PR DESCRIPTION
Compatible with the previous two x2wasm-cli.

In addition, the commands are shorter and simpler than `hooks-cli contract-c` and `hooks-cli contract-js`.