### PR TITLE
fix args.headers handling in compileCCommand

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -186,12 +186,13 @@ export const compileCCommand = async (
     });
   }
 
-  if (args.headers) {
-    if (typeof args.headers !== "string") {
+  const headersPath = args?.headers;
+  if (headersPath) {
+    if (typeof headersPath !== "string") {
       console.error("headers path must be a string.");
       process.exit(1);
     }
-    const dirStat = fs.statSync(args.headers);
+    const dirStat = fs.statSync(headersPath);
     if (!dirStat.isDirectory()) {
       console.error("headers path must be a directory.");
       process.exit(1);
@@ -200,9 +201,9 @@ export const compileCCommand = async (
 
   const dirStat = fs.statSync(inPath);
   if (dirStat.isDirectory()) {
-    await buildCDir(inPath, outDir, args.headers);
+    await buildCDir(inPath, outDir, headersPath);
   } else {
-    await buildCFile(inPath, outDir, args.headers);
+    await buildCFile(inPath, outDir, headersPath);
   }
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
      "outDir": "./dist/npm",
      "declaration": true,
      "declarationMap": true,
-     "strictNullChecks": false,
+     "strictNullChecks": true,
      "noImplicitAny": true,
      "noUnusedLocals": true,
      "removeComments": true,


### PR DESCRIPTION
## High Level Overview of Change

Fixed because the following error occurred when args was not specified.
`Cannot read properties of undefined (reading 'headers')`

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->